### PR TITLE
fix username on water supply layout

### DIFF
--- a/layouts/metadata/water_supply.xml
+++ b/layouts/metadata/water_supply.xml
@@ -2,5 +2,5 @@
 <metadata>
     <option iso="es" name="Español"> Este layout permite mapear diferentes tipos de pozos de agua, como pozos en uso, pozos recién descubiertos o pozos contaminados </option>
     <option iso="en" name="English"> This layout allows you to map different kinds of water supplies like some that are in use right now, new water supply discovered or contaminated ones. </option>
-    <github username="xsaco07" repo="osmtracker-android-layouts" branch="master" />
+    <github username="labexp" repo="osmtracker-android-layouts" branch="master" />
 </metadata>


### PR DESCRIPTION
Based on the [wiki](https://github.com/labexp/osmtracker-android-layouts/wiki), in the metadata file the  username is the GitHub username of the owner of the repository. This PR fix that in the water supply layout.