### PR TITLE
Added "onlyphoto" layout.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This is OSMTracker's default repository for download custom layouts functionalit
 + [Macroplastics pollution](https://github.com/labexp/osmtracker-android-layouts/blob/master/layouts/macroplastics_pollution/README.md)
 + [Max Speed.](https://github.com/labexp/osmtracker-android-layouts/blob/master/layouts/maxspeed/README.md)
 + [Max Speed USA.](https://github.com/labexp/osmtracker-android-layouts/blob/master/layouts/maxspeed_usa/README.md)
++ [Only photo.](https://github.com/hlinden/osmtracker-android-layouts/blob/master/layouts/onlyphoto/README.md)
 + [Transporte público.](https://github.com/labexp/osmtracker-android-layouts/blob/master/layouts/transporte_publico/README.md)
 + [Walk Ride Detailed.](https://github.com/Nick-Tallguy/osmtracker-android-layouts/blob/master/layouts/walk_ride_detailed/readme.md)
 + [Water Supplies.](https://github.com/labexp/osmtracker-android-layouts/blob/master/layouts/water_supply/README.md)

--- a/layouts/metadata/onlyphoto.xml
+++ b/layouts/metadata/onlyphoto.xml
@@ -1,0 +1,6 @@
+
+<metadata>
+    <option iso="en" name="English"> Just a single, huge photo button. </option>
+    <option iso="de" name="Deutsch"> Einfach ein einzelner, großer Knopf für Fotos. </option>
+    <github username="hlinden" repo="osmtracker-android-layouts" branch="master" />
+</metadata>

--- a/layouts/onlyphoto/README.md
+++ b/layouts/onlyphoto/README.md
@@ -1,0 +1,4 @@
+## Onlyphoto layout
+This "layout" consists of a single, big camera button and is designed for just taking photos and mapping later at home.
+It is extremely useful when handling the phone with one hand while hiking, when there is no time for detailed data collection anyway.
+To reduce the neccessary interaction even further, set the standard picture source to "camera" in OSMTracker.

--- a/layouts/onlyphoto/de.xml
+++ b/layouts/onlyphoto/de.xml
@@ -1,0 +1,7 @@
+<layouts>
+        <layout name="root">
+		<row>
+			<button type="picture" icon="logo_camera"/>
+		</row>
+        </layout>
+</layouts>

--- a/layouts/onlyphoto/en.xml
+++ b/layouts/onlyphoto/en.xml
@@ -1,0 +1,7 @@
+<layouts>
+        <layout name="root">
+		<row>
+			<button type="picture" icon="logo_camera"/>
+		</row>
+        </layout>
+</layouts>


### PR DESCRIPTION
I added an extremely simple layout that only presents a single, big button for taking pictures. 

When I'm hiking, I'm often wearing gloves, I'm handling my dog, I don't want fiddle with OSM-Tracker - I just want a picture of the situation and map at home later. Just having one big button that is easy to hit meets exactly that requirement.